### PR TITLE
Fixed paths from Frends.Radon.nuspec

### DIFF
--- a/nuspec/Frends.Radon.nuspec
+++ b/nuspec/Frends.Radon.nuspec
@@ -16,7 +16,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Output\Frends.Radon.dll" target="lib\net40" />
-    <file src="Output\FrendsTaskMetadata.json" target="tools\" />
+    <file src="Frends.Radon\bin\Release\Frends.Radon.dll" target="lib\net40" />
+    <file src="Frends.Radon\bin\Release\FrendsTaskMetadata.json" target="tools\" />
   </files>
 </package>


### PR DESCRIPTION
Fixed paths from Frends.Radon.nuspec to point to the correct build results directory now that the custom .proj build was removed