### PR TITLE
Replaced Frends.tasks.attributes with System.ComponentModel.DataAnnotations

### DIFF
--- a/Frends.Radon/Frends.Radon.csproj
+++ b/Frends.Radon/Frends.Radon.csproj
@@ -44,11 +44,9 @@
     <Reference Include="Dynamic, Version=1.0.0.0, Culture=neutral, PublicKeyToken=68293a411f0cabcc, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamicQuery.1.0\lib\35\Dynamic.dll</HintPath>
     </Reference>
-    <Reference Include="Frends.Tasks.Attributes, Version=1.2.0.0, Culture=neutral, PublicKeyToken=258fd606323928fc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.1\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Frends.Radon/Mailer.cs
+++ b/Frends.Radon/Mailer.cs
@@ -1,31 +1,31 @@
 ﻿using System.ComponentModel;
-using Frends.Tasks.Attributes;
+using System.ComponentModel.DataAnnotations;
 
 namespace Frends.Radon
 {
     public class MailerSettings
     {
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("Frends Radon")]
         public string SenderName { get; set; }
 
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("notification_noreply@example.org")]
         public string SenderAddress { get; set; }
 
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("john.doe@example.org; jane.doe@example.org")]
         public string Recipients { get; set; }
 
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("System event report")]
         public string Subject { get; set; }
 
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("You've got mail!")]
         public string MessageContent { get; set; }
 
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("smtp.somedomain.com")]
         public string SmtpServerName { get; set; }
 
@@ -38,21 +38,21 @@ namespace Frends.Radon
         [DefaultValue("true")]
         public bool UseWindowsCredentials { get; set; }
 
-        [ConditionalDisplay(nameof(UseWindowsCredentials), "false")]
-        [DefaultDisplayType(DisplayType.Text)]
+        [UIHint(nameof(UseWindowsCredentials), "", false)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("")]
         public string Username { get; set; }
 
         [PasswordPropertyText]
-        [DefaultDisplayType(DisplayType.Text)]
-        [ConditionalDisplay(nameof(UseWindowsCredentials), "false")]
+        [DisplayFormat(DataFormatString = "Text")]
+        [UIHint(nameof(UseWindowsCredentials), "", false)]
         [DefaultValue("")]
         public string Password { get; set; }
 
         [DefaultValue(1000)]
         public int MaxIdleTime { get; set; }
 
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("")]
         public string TemplateFile { get; set; }
     }

--- a/Frends.Radon/Reporter.cs
+++ b/Frends.Radon/Reporter.cs
@@ -1,29 +1,29 @@
 ﻿using System;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Threading;
-using Frends.Tasks.Attributes;
 
 namespace Frends.Radon
 {
     public class EmailSettings
     {
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("System event report")]
         public string Subject { get; set; }
 
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("Frends Radon")]
         public string SenderName { get; set; }
 
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("notification_noreply@example.org")]
         public string SenderAddress { get; set; }
 
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("john.doe@example.org; jane.doe@example.org")]
         public string Recipients { get; set; }
 
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("smtp.somedomain.com")]
         public string SmtpServerName { get; set; }
 
@@ -36,57 +36,57 @@ namespace Frends.Radon
         [DefaultValue("true")]
         public bool UseWindowsCredentials { get; set; }
 
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("")]
-        [ConditionalDisplay(nameof(UseWindowsCredentials), false)]
+        [UIHint(nameof(UseWindowsCredentials), "", false)]
         public string Username { get; set; }
 
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("")]
-        [ConditionalDisplay(nameof(UseWindowsCredentials), false)]
+        [UIHint(nameof(UseWindowsCredentials), "", false)]
         [PasswordPropertyText]
         public string Password { get; set; }
 
         [DefaultValue(1000)]
         public int MaxIdleTime { get; set; }
 
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("")]
         public string TemplateFile { get; set; }
     }
 
     public class FilterSettings
     {
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("EntryType = \"Error\"")]
         public string FilterString { get; set; }
 
-        [DefaultDisplayType(DisplayType.Expression)]
+        [DisplayFormat(DataFormatString = "Expression")]
         [DefaultValue("TimeSpan.FromDays(1)")]
         public TimeSpan MaxTimespan { get; set; }
 
         [DefaultValue(EventSource.EventLog)]
         public EventSource EventSource { get; set; }
 
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("")]
         public string ExternalEventsXml { get; set; }
 
         [DefaultValue(200)]
         public int MaxMessages { get; set; }
 
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("")]
         public string RemoteMachine { get; set; }
 
-        [DefaultDisplayType(DisplayType.Text)]
+        [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("")]
         public string EventLogName { get; set; }
     }
 
     public class Reporter
     {
-        public static RadonResult Execute([CustomDisplay(DisplayOption.Tab)]EmailSettings email, [CustomDisplay(DisplayOption.Tab)]FilterSettings filter, CancellationToken cancellationToken)
+        public static RadonResult Execute([PropertyTab]EmailSettings email, [PropertyTab]FilterSettings filter, CancellationToken cancellationToken)
         {
             var radonExecutor = new RadonExecutor(new RadonConfigurationManager(email, filter));
             var radonProgram = new RadonProgram(radonExecutor);

--- a/Frends.Radon/packages.config
+++ b/Frends.Radon/packages.config
@@ -2,5 +2,4 @@
 <packages>
   <package id="DotLiquid" version="1.7.0" targetFramework="net4" />
   <package id="DynamicQuery" version="1.0" targetFramework="net40" />
-  <package id="Frends.Tasks.Attributes" version="1.2.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Replaced usage of custom attributes from Frends.tasks.attributes with their counterparts from System.ComponentModel.DataAnnotations, as the Frends.Tasks.Attributes reference mostly does not work together with older versions